### PR TITLE
Remove preinstall script

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,25 @@ npm install node-red-contrib-eddystone -g
 
 ## Prerequisites
 
-**node-red-contrib-eddystone** is based on the awesome [node-eddystone-beacon](https://github.com/don/node-eddystone-beacon). However, node-eddystone-beacon has the same [prerequesits](https://github.com/don/node-eddystone-beacon#prerequisites) you might want to check. For instance, you might need to run Node-RED with root permissions for accessing the Bluetooth interface depending on your setup.
+**node-red-contrib-eddystone** is based on the awesome [node-eddystone-beacon](https://github.com/don/node-eddystone-beacon). However, node-eddystone-beacon has the same [prerequesits](https://github.com/don/node-eddystone-beacon#prerequisites) you might want to check. 
+
+You can install the prerequisite packages with the following command
+
+```
+sudo apt-get install -y bluetooth bluez libbluetooth-dev libudev-dev
+```
+
+On Linux Bluetooth LE requires root access to the hardware to work, you can achive this by running Node-RED as root or by setting the required flags on the node binary with the following command.
+
+```
+sudo setcap cap_net_raw+eip $(eval readlink -f `which node`)
+```
+
+setcap can be installed with the following command if needed
+
+```
+sudo apt-get install libcap2-bin
+```
 
 We recommend to use a Raspberry Pi with a Bluetooth 4.0 compatible USB dongle.
 

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
   "name": "node-red-contrib-eddystone",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Creating Eddystone beacons with Node RED.",
-  "authos": "matboehmer",
+  "authors": "matboehmer",
   "dependencies": {
     "eddystone-beacon": "1.0.3"
   },
   "scripts":{
-	"preinstall":"apt-get update; apt-get install -y bluetooth bluez libbluetooth-dev libudev-dev"
+	
   },
   "installation-duration":350,
   "keywords": [


### PR DESCRIPTION
The script meant that the node could only be installed on as root
on Linux. The node will work fine on OSx and doesn't need to be
root with the right flags set on node binary.

Fixes #3 